### PR TITLE
hardcode CSS color codes

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -859,8 +859,8 @@ div::-webkit-scrollbar-thumb {
 /* thread side panel */
 
 #mentions_scroller {
-   background: var(--background) !important;
-   color: var(--text) !important;
+   background: #282C34 !important;
+   color: #ABB2BF !important;
 }
 
 


### PR DESCRIPTION
Attempting to hard code the CSS color code instead of using the variable to directly override the custom CSS formatting done on the javascript side.